### PR TITLE
IFIX-616

### DIFF
--- a/frontend/mgramseva/lib/providers/household_register_provider.dart
+++ b/frontend/mgramseva/lib/providers/household_register_provider.dart
@@ -158,7 +158,7 @@ class HouseholdRegisterProvider with ChangeNotifier {
         apiKey: 'connectionNumber ',
         callBack: onSort),
     TableHeader(i18.common.NAME,
-        isSortingRequired: true,
+        isSortingRequired: false,
         isAscendingOrder: sortBy != null && sortBy!.key == 'name'
             ? sortBy!.isAscending
             : null,


### PR DESCRIPTION
Name Sorting can not be implemented due to data encryption,Hence, removing the sorting upon the name field